### PR TITLE
make sure base64 img urls are unchanged

### DIFF
--- a/mkdocs_print_site_plugin/urls.py
+++ b/mkdocs_print_site_plugin/urls.py
@@ -41,6 +41,13 @@ def is_external(url):
     prefixes = ("http", "www", "mailto:", "tel:", "skype:", "ftp:")
     return url.startswith(prefixes)
 
+def is_base64_image(url):
+    """
+    Test if a url is a base64 data image.
+    """
+    prefixes = ("data:image")
+    return url.startswith(prefixes)
+
 
 def is_attachment(url):
     """
@@ -211,6 +218,9 @@ def fix_image_src(page_html, page_url, directory_urls):
         img_src = m.group(1)
         if is_external(img_src):
             continue
+        elif is_base64_image(img_src):
+            continue
+        
         img_text = m.group()
 
         new_url = get_url_from_root(img_src, page_url)

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -160,10 +160,14 @@ def test_fix_image_src():
     html = "<td>Wraps the hero teaser (if available)</td>\n</tr>\n<tr>\n<td><code>htmltitle</code></td>\n<td>Wraps the <code><title></code> tag</td>\n</tr>\n<tr>\n<td><code>libs</code></td>\n<td>Wraps"  # noqa
     assert fix_image_src(html, "this_page", True) == html
 
-    # Make sure absolute urls stay intct
+    # Make sure absolute urls stay intact
     html = '<img src="/img.png">'
     assert fix_image_src(html, "this_page", False) == html
 
+    # Make sure base64 images stay intact
+    html = '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=">'
+    assert fix_image_src(html, "this_page", False) == html
+    
     # Make sure changes are made
     html = '<img src="../appendix/table.png">'
     result = '<img src="../appendix/table.png">'


### PR DESCRIPTION
When using mkdocs with jupyter notebooks some graphs are outputted as base64 images. Added a test for image urls that start with data:image and leaves them unchanged.

Signed-off-by: Lasse Lambrechts <lasse.lambrechts@bt.no>