### PR TITLE
Allow empty context if custom theme

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,7 +33,7 @@ To quickly serve a website with your latest changes to the plugin use the sites 
 ```bash
 pip install -r tests/test_requirements.txt
 pip install -e .
-mkdocs serve -f tests/fixutures/basic/mkdocs.yml
+mkdocs serve -f tests/fixtures/projects/basic/mkdocs.yml
 ```
 
 Tip: If you use google chrome, you can also view the print version of a page inside the browser [by setting the renderer](https://www.smashingmagazine.com/2018/05/print-stylesheets-in-2018/).

--- a/mkdocs_print_site_plugin/plugin.py
+++ b/mkdocs_print_site_plugin/plugin.py
@@ -297,7 +297,7 @@ class PrintSitePlugin(BasePlugin):
         if not self.config.get("enabled"):
             return
 
-        if len(self.context) == 0:
+        if len(self.context) == 0 and get_theme_name(config) != None:
             msg = "Could not find a template context.\n"
             msg += "Report an issue at https://github.com/timvink/mkdocs-print-site-plugin\n"
             msg += f"And mention the template you're using: {get_theme_name(config)}"
@@ -347,7 +347,7 @@ class PrintSitePlugin(BasePlugin):
 
         # Remove lazy loading attributes from images
         # https://regex101.com/r/HVpKPs/1
-        html = re.sub(r"(\<img.+)(loading=\"lazy\")", r"\1", html)        
+        html = re.sub(r"(\<img.+)(loading=\"lazy\")", r"\1", html)
 
         # Compatiblity with mkdocs-chart-plugin
         # As this plugin adds some javascript to every page


### PR DESCRIPTION
- Bypass empty context when using `theme: null`.
- Example command path/spell error fix.