### PR TITLE
Compatibility with MkDocs 1.5 change to extra_javascript

### DIFF
--- a/mkdocs_print_site_plugin/plugin.py
+++ b/mkdocs_print_site_plugin/plugin.py
@@ -284,7 +284,7 @@ class PrintSitePlugin(BasePlugin):
             if config.get('extra_css'):
                 self.context['extra_css'] = [get_relative_url(f, self.print_page.file.url) for f in config.get('extra_css')]
             if config.get('extra_javascript'):
-                self.context['extra_javascript'] = [get_relative_url(f, self.print_page.file.url) for f in config.get('extra_javascript')]
+                self.context['extra_javascript'] = [get_relative_url(str(f), self.print_page.file.url) for f in config.get('extra_javascript')]
 
 
     def on_post_build(self, config, **kwargs):


### PR DESCRIPTION
Convert `extra_javascript` items to strings before treating them as paths, because they can now be `ExtraScriptValue` instead.

* Fixes #86

This is a bit of a [breaking change in MkDocs 1.5.0](https://www.mkdocs.org/about/release-notes/#script-tags-can-specify-typemodule-and-other-attributes). Sorry about the breakage.