### PR TITLE
Run on_post_page for print_page

### DIFF
--- a/mkdocs_print_site_plugin/plugin.py
+++ b/mkdocs_print_site_plugin/plugin.py
@@ -387,6 +387,8 @@ class PrintSitePlugin(BasePlugin):
         )
         html = html.replace("</head>", print_site_js + "</head>")
 
+        html = config.plugins.on_post_page(html, page=self.print_page, config=config)
+
         # Write the print_page file to the output folder
         write_file(
             html.encode("utf-8", errors="xmlcharrefreplace"),


### PR DESCRIPTION
Background: I'm using an `on_post_page` hook (using [mkdocs-simple-hooks](https://github.com/aklajnert/mkdocs-simple-hooks)  )to replace URLs on all pages. However, since this plugin does not pass it's final output through the `on_post_page` hook links on my print_page are currently wrong. Other plugins such as [mkdocs-glightbox](https://github.com/blueswen/mkdocs-glightbox) also depend on this hook.

I've tested that this doesn't break anything with my current setup, but since I'm new to MkDocs I don't know much about whether this may break any guarantees MkDocs makes with regard to event order. After all `on_post_page` is called from `on_post_build`.