### PR TITLE
add mkdocs-drawio plugin support

### DIFF
--- a/mkdocs_print_site_plugin/plugin.py
+++ b/mkdocs_print_site_plugin/plugin.py
@@ -357,6 +357,18 @@ class PrintSitePlugin(BasePlugin):
                 .add_javascript_variables(html, self.print_page, config)
             )
 
+        # Compatibility with mkdocs-drawio
+        # As this plugin adds renderer html for every drawio diagram
+        # referenced in your markdown files. This rendering happens
+        # in the on_post_page event, which is skipped by this plugin
+        # therefore we need to manual execute the drawio plugin renderer here. 
+        if config.get("plugins", {}).get("drawio"):
+            html = (
+                config.get("plugins", {})
+                    .get("drawio")
+                    .render_drawio_diagrams(html, self.print_page)
+            )
+
         # Compatibility with https://github.com/g-provost/lightgallery-markdown
         # This plugin insert link hrefs with double dashes, f.e.
         # <link href="//assets/css/somecss.css">

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r", encoding="UTF-8") as f:
 
 setup(
     name="mkdocs-print-site-plugin",
-    version="2.3.6",
+    version="2.4.0",
     description="MkDocs plugin that combines all pages into one, allowing for easy export to PDF and standalone HTML.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Motivation
Support printing drawio diagrams. The diagram rendering happens in `on_post_page` which is skipped by this plugin and therefore we explicitly need to add support for `mkdocs-drawio` for printing drawio diagrams.


# More details
Details regarding the implementation and reasoning can be found here: #99

The latest version of `mkdocs-drawio` `1.6.0` adds support for printing with this plugin.
https://github.com/tuunit/mkdocs-drawio/commit/b26a7f3a303e3f82fda519ab40fd181b8adba314


# How has this been tested
I've added the `mkdocs-print-site-plugin` to the example directory in `mkdocs-drawio` and tested the `/print_page/` endpoint and PDF generation:

![image](https://github.com/timvink/mkdocs-print-site-plugin/assets/18513179/3c247e7a-59bf-4a2f-b21f-71900af6b978)

![image](https://github.com/timvink/mkdocs-print-site-plugin/assets/18513179/c0d75781-1a35-4cd2-a3d4-bad43e39252f)

