### PR TITLE
New CSS for readthedocs

### DIFF
--- a/mkdocs_print_site_plugin/css/print-site-readthedocs.css
+++ b/mkdocs_print_site_plugin/css/print-site-readthedocs.css
@@ -1,0 +1,35 @@
+/* Print styles for readthedocs theme  */
+
+#print-site-banner { 
+    padding-top: 1em;
+ }
+
+
+ /* Table of contents, proper padding */
+.print-page-toc-title {
+    padding-bottom: 0em;
+    margin-bottom: 1em;
+}
+ /* Table of contents, compatible with dark theme */
+ #print-site-page ul.toc-section-line-border { 
+    border-left: 5px solid rgb(225, 225, 225);
+ }
+
+@page {
+
+    /* 
+        Note this CSS file is added to all MkDocs pages
+        So this @page logic will affect print of all pages
+    */
+
+    size: a4 portrait;
+    margin: 15mm 10mm 15mm 10mm;
+    counter-increment: page;
+
+    @bottom-center {
+        content: string(chapter);
+    }
+    @bottom-right {
+        content: 'Page ' counter(page);
+    }
+}


### PR DESCRIPTION
Created CSS for readthedocs-theme, derived from mkdocs-css.
Closes issue #82