### PR TITLE
Multi print page

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -23,6 +23,7 @@ plugins:
       enabled: true
       exclude:
       include:
+      print_docs_dir: ""
 ```
 
 `add_to_navigation`
@@ -95,3 +96,5 @@ plugins:
 : Default is empty. Allows to specify a list of page source paths that should not be included in the print page. See [Do Not Print](how-to/do_not_print.md#ignoring-an-entire-page) for more info.
 `include`
 : Default is * to include the entire site. Allows to specify a list of page source paths that is then filtered by the exclude options to create a final list that should be included in the print page. 
+`print_docs_dir`
+: Default is "" to use the site docs_dir.  This can be set to a sub folder of the site docs_dir to set the root for print_site.  

--- a/docs/options.md
+++ b/docs/options.md
@@ -22,6 +22,7 @@ plugins:
       include_css: true
       enabled: true
       exclude:
+      include:
 ```
 
 `add_to_navigation`
@@ -92,3 +93,5 @@ plugins:
 
 `exclude`
 : Default is empty. Allows to specify a list of page source paths that should not be included in the print page. See [Do Not Print](how-to/do_not_print.md#ignoring-an-entire-page) for more info.
+`include`
+: Default is * to include the entire site. Allows to specify a list of page source paths that is then filtered by the exclude options to create a final list that should be included in the print page. 

--- a/docs/options.md
+++ b/docs/options.md
@@ -24,6 +24,9 @@ plugins:
       exclude:
       include:
       print_docs_dir: ""
+      pages_to_print:
+      - page_name: 'print_page'
+        config:
 ```
 
 `add_to_navigation`
@@ -95,6 +98,76 @@ plugins:
 `exclude`
 : Default is empty. Allows to specify a list of page source paths that should not be included in the print page. See [Do Not Print](how-to/do_not_print.md#ignoring-an-entire-page) for more info.
 `include`
-: Default is * to include the entire site. Allows to specify a list of page source paths that is then filtered by the exclude options to create a final list that should be included in the print page. 
+: Default is * to include the entire site. Allows to specify a list of page source paths that is then filtered by the exclude options to create a final list that should be included in the print page. This does not change the root.
 `print_docs_dir`
-: Default is "" to use the site docs_dir.  This can be set to a sub folder of the site docs_dir to set the root for print_site.  
+: Default is "*" to use the site docs_dir.  This can be set to a sub folder of the site docs_dir to set the new root for the PDF print page.  
+
+`pages_to_print`
+: This is to define multiple pdf print areas with their own config sections that allow overriding the global parameters.
+
+`page_name`
+: This is the name of the page to be used to access the pdf print page. e.g.  sitename/%page_name%
+`config`
+: Configurations specific to the page_name that override the global level options. 
+
+
+## Multiple PDFs
+A site can contain directory structures to support various aspects of a business or product.  Help Guides, Setup Guides, Onboarding Guides or Maintenance processes.  These areas often consist of multiple markdown pages of content that would need to be aggregated using the mkdocs_print_site_plugin into a single page.   The pages_to_print section allows defining the name of the single page and config overrides for that PDF page. 
+
+If the pages_to_print is not present the configuration settings for a single 'print_page' will apply. 
+
+```yml
+  - print-site:
+      add_cover_page: true
+      cover_page_template: "docs/assets/cover_page_policy.tpl"
+      add_table_of_contents: true
+      add_print_site_banner: false
+      pages_to_print:
+      - page_name: 'print_page'
+        config:
+          - add_table_of_contents: true
+          - add_print_site_banner: false
+          - print_page_title: "Full Web Site"
+      - page_name: 'print_policy_page'
+        config:
+          - add_table_of_contents: true
+          - add_print_site_banner: false
+          - print_page_title: "Policy"
+          - print_docs_dir: "Reference/Policies"
+      - page_name: 'print_presales'
+        config:
+          - add_table_of_contents: false
+          - add_print_site_banner: true
+          - print_page_title: "Pre Sales Guide"
+          - print_docs_dir: "Reference/Pre Sales Guide"
+          - exclude:
+              - InternalProcesses*
+      - page_name: 'print_summer_catalog'
+        config:
+          - add_cover_page: true
+          - add_table_of_contents: true
+          - add_print_site_banner: false
+          - print_page_title: "Summer Catalog"
+          - cover_page_template: "docs/assets/cover_page_summer_catalog.tpl"
+          - include:
+            - jetskis*
+            - motorbikes*
+          - exclude:
+            - data*
+      - page_name: 'print_winter_catalog'
+        config:
+          - add_cover_page: true
+          - add_table_of_contents: true
+          - add_print_site_banner: false
+          - print_page_title: "Winter Catalog"
+          - include:
+            - snowmobiles*
+            - skiis*
+          - exclude:
+            - data*
+          - cover_page_template: "docs/assets/cover_page_winter_catalog.tpl"
+
+```
+
+The example above is contrived, but illustrates generation of pdfs for different topics or areas of a docs site.  
+

--- a/mkdocs_print_site_plugin/plugin.py
+++ b/mkdocs_print_site_plugin/plugin.py
@@ -43,7 +43,7 @@ class PrintSitePlugin(BasePlugin):
         ("enabled", config_options.Type(bool, default=True)),
         ("exclude", config_options.Type(list, default=[])),
         ("include", config_options.Type(list, default=["*"])),
-        ("print_docs_dir", config_options.Type(str, default="")),
+        ("print_docs_dir", config_options.Type(str, default="*")),
         ("pages_to_print", config_options.Type(list, default=[])),
     )
     page_renderers = {}
@@ -278,24 +278,27 @@ class PrintSitePlugin(BasePlugin):
                 continue
             # Save the (order of) pages and sections in the navigation before adding the print page
             print_dir=page_config['print_docs_dir']
-            new_root = find_new_root(nav.items,print_dir )
-            # If x == None the print_docs_dir is an invalid path.
-            if new_root is None:
-                msg = f'[mkdocs-print-site] Warning the \'print_docs_dir\' path '
-                msg += f'{page_config["print_docs_dir"]} is invalid for page_name: {page_name}. '
-                msg += "Format is Section\Section\Section.  This corresponds "
-                msg += "to Directory\Directory\Directory, but mkdocs will upper case "
-                msg += "a Directory from 'project' to 'Project'"
-                msg += "Please update the 'plugins:' section in your mkdocs.yml"
-                logger.warning(msg)
-            else:
-                if hasattr(new_root, 'children'):
-                    self.page_renderers[page_name].items = new_root.children
-                    page_config['all_pages_in_nav'] = flatten_nav(new_root.children)
+            if print_dir != "*":
+                new_root = find_new_root(nav.items,print_dir )
+                # If x == None the print_docs_dir is an invalid path.
+                if new_root is None:
+                    msg = f'[mkdocs-print-site] Warning the \'print_docs_dir\' path '
+                    msg += f'{page_config["print_docs_dir"]} is invalid for page_name: {page_name}. '
+                    msg += "Check the path.  If correct the format is Section\\Section\\Section.  "
+                    msg += "This corresponds to Directory\\Directory\\Directory, but mkdocs "
+                    msg += "will upper case a Directory from 'project' to 'Project'. "
+                    msg += "Please update the 'plugins:' section in your mkdocs.yml"
+                    logger.warning(msg)
                 else:
-                    self.page_renderers[page_name].items = new_root
-                    page_config['all_pages_in_nav'] = flatten_nav(new_root)
-
+                    if hasattr(new_root, 'children'):
+                        self.page_renderers[page_name].items = new_root.children
+                        page_config['all_pages_in_nav'] = flatten_nav(new_root.children)
+                    else:
+                        self.page_renderers[page_name].items = new_root
+                        page_config['all_pages_in_nav'] = flatten_nav(new_root)
+            else:
+                self.page_renderers[page_name].items = nav.items
+                page_config['all_pages_in_nav'] = flatten_nav(nav.items)
 
             # Optionally add the print page to the site navigation
             if self.config.get("add_to_navigation"):

--- a/mkdocs_print_site_plugin/plugin.py
+++ b/mkdocs_print_site_plugin/plugin.py
@@ -301,9 +301,9 @@ class PrintSitePlugin(BasePlugin):
                 page_config['all_pages_in_nav'] = flatten_nav(nav.items)
 
             # Optionally add the print page to the site navigation
-            if self.config.get("add_to_navigation"):
-                nav.items.append(self.print_page)
-                nav.pages.append(self.print_page)
+            if page_config['add_to_navigation']:
+                nav.items.append(page_config['print_page'])
+                nav.pages.append(page_config['print_page'])
 
 
         return nav

--- a/mkdocs_print_site_plugin/plugin.py
+++ b/mkdocs_print_site_plugin/plugin.py
@@ -42,6 +42,7 @@ class PrintSitePlugin(BasePlugin):
         ("include_css", config_options.Type(bool, default=True)),
         ("enabled", config_options.Type(bool, default=True)),
         ("exclude", config_options.Type(list, default=[])),
+        ("include", config_options.Type(list, default=["*"])),
     )
 
     def on_config(self, config, **kwargs):

--- a/mkdocs_print_site_plugin/plugin.py
+++ b/mkdocs_print_site_plugin/plugin.py
@@ -278,13 +278,23 @@ class PrintSitePlugin(BasePlugin):
                 continue
             # Save the (order of) pages and sections in the navigation before adding the print page
             print_dir=page_config['print_docs_dir']
-            x = find_new_root(nav.items,print_dir )
-            if hasattr(x, 'children'):
-                self.page_renderers[page_name].items = x.children
-                page_config['all_pages_in_nav'] = flatten_nav(x.children)
+            new_root = find_new_root(nav.items,print_dir )
+            # If x == None the print_docs_dir is an invalid path.
+            if new_root is None:
+                msg = f'[mkdocs-print-site] Warning the \'print_docs_dir\' path '
+                msg += f'{page_config["print_docs_dir"]} is invalid for page_name: {page_name}. '
+                msg += "Format is Section\Section\Section.  This corresponds "
+                msg += "to Directory\Directory\Directory, but mkdocs will upper case "
+                msg += "a Directory from 'project' to 'Project'"
+                msg += "Please update the 'plugins:' section in your mkdocs.yml"
+                logger.warning(msg)
             else:
-                self.page_renderers[page_name].items = x
-                page_config['all_pages_in_nav'] = flatten_nav(x)
+                if hasattr(new_root, 'children'):
+                    self.page_renderers[page_name].items = new_root.children
+                    page_config['all_pages_in_nav'] = flatten_nav(new_root.children)
+                else:
+                    self.page_renderers[page_name].items = new_root
+                    page_config['all_pages_in_nav'] = flatten_nav(new_root)
 
 
             # Optionally add the print page to the site navigation

--- a/mkdocs_print_site_plugin/plugin.py
+++ b/mkdocs_print_site_plugin/plugin.py
@@ -180,7 +180,6 @@ class PrintSitePlugin(BasePlugin):
         # If not add default single site content
             self.print_pages[global_page["page_name"]]=global_page['config']
 
-
         # Loop though the self.print_pages and 
         # convert the single page self._____ attribute storage 
         # to a self.print_pages[key]._____ attribute storage 

--- a/mkdocs_print_site_plugin/plugin.py
+++ b/mkdocs_print_site_plugin/plugin.py
@@ -174,7 +174,7 @@ class PrintSitePlugin(BasePlugin):
                 #validate the data
                 validate_page_entry(new_page)
                 self.print_pages[new_page["page_name"]] =merge_config(
-                                                            global_page[config],
+                                                            global_page['config'],
                                                             convert_config_to_dict(new_page["config"]))
         else:
         # If not add default single site content
@@ -304,7 +304,7 @@ class PrintSitePlugin(BasePlugin):
         """
         if not self.config.get("enabled"):
             return html
-        html_pages = [val['print_page'] for k, val in self.print_pages]
+        html_pages = [val['print_page'] for k, val in self.print_pages.items()]
         
         for page_name, page_config in self.print_pages.items():
             if not page_config['enabled']:
@@ -373,10 +373,10 @@ class PrintSitePlugin(BasePlugin):
             if template_name == "404.html":
                 page_config['context'] = context
                 # Make sure paths are OK
-                if page_config['extra_css']:
-                    page_config['context']['extra_css'] = [get_relative_url(f, page_config['print_page'].file.url) for f in page_config['extra_css']]
-                if page_config['extra_javascript']:
-                    self.context['extra_javascript'] = [get_relative_url(str(f), page_config['print_page'].file.url) for f in page_config['extra_javascript']]
+                if config.get('extra_css'):
+                    page_config['context']['extra_css'] = [get_relative_url(f, page_config['print_page'].file.url) for f in config.get('extra_css')]
+                if config.get('extra_javascript'):
+                    page_config['context']['extra_javascript'] = [get_relative_url(str(f), page_config['print_page'].file.url) for f in config.get('extra_javascript')]
 
 
     def on_post_build(self, config, **kwargs):

--- a/mkdocs_print_site_plugin/renderer.py
+++ b/mkdocs_print_site_plugin/renderer.py
@@ -82,6 +82,8 @@ class Renderer(object):
             for item in items:
                 if item.is_page:
                     # Do not exclude page in print page if included
+                    if "Policies" in item.file.src_path:
+                        x = item.file.src_path
                     if not exclude(item.file.src_path,included_pages):
                         logging.debug(f"Excluding page '{item.file.src_path}'")
                         continue
@@ -149,7 +151,7 @@ class Renderer(object):
         html += get_html_from_items(
             self._get_items(),
             dir_urls=self.mkdocs_config.get("use_directory_urls"),
-            included_pages=self.plugin_config.get("included", []),
+            included_pages=self.plugin_config.get("include", []),
             excluded_pages=self.plugin_config.get("exclude", [])
         )
 

--- a/mkdocs_print_site_plugin/renderer.py
+++ b/mkdocs_print_site_plugin/renderer.py
@@ -164,7 +164,7 @@ class Renderer(object):
         Inserts the cover page.
         """
         env = jinja2.Environment()
-        env.globals = {"config": self.mkdocs_config, "page": self.print_page}
+        env.globals = {"config": self.mkdocs_config, "page": self.print_page, "page_config": self.page_config}
 
         with open(
             self.cover_page_template_path, "r", encoding="utf-8-sig", errors="strict"
@@ -187,7 +187,7 @@ class Renderer(object):
         Inserts the print site banner.
         """
         env = jinja2.Environment()
-        env.globals = {"config": self.mkdocs_config, "page": self.print_page}
+        env.globals = {"config": self.mkdocs_config, "page": self.print_page, "page_config": self.page_config}
 
         with open(
             self.banner_template_path, "r", encoding="utf-8-sig", errors="strict"

--- a/mkdocs_print_site_plugin/renderer.py
+++ b/mkdocs_print_site_plugin/renderer.py
@@ -62,7 +62,7 @@ class Renderer(object):
         html = '<div id="print-site-page" class="%s">' % " ".join(enabled_classes)
 
         # Enable options via HTML injection
-        if self.page_config['add_cover_page':
+        if self.page_config['add_cover_page']:
             html += self._cover_page()
 
         if self.page_config['add_print_site_banner']:
@@ -151,8 +151,8 @@ class Renderer(object):
         html += get_html_from_items(
             self._get_items(),
             dir_urls=self.mkdocs_config.get("use_directory_urls"),
-            included_pages=self.page_config['include],
-            excluded_pages=self.page_config['exclude']'
+            included_pages=self.page_config['include'],
+            excluded_pages=self.page_config['exclude']
         )
 
         html += "</div>"
@@ -208,9 +208,9 @@ class Renderer(object):
         """
         return f"""
         <section class="print-page">
-            <div id="print-page-toc" data-toc-depth="{self.plugin_config.get("toc_depth")}">
+            <div id="print-page-toc" data-toc-depth="{self.page_config["toc_depth"]}">
                 <nav role='navigation' class='print-page-toc-nav'>
-                <h1 class='print-page-toc-title'>{self.plugin_config.get("toc_title")}</h1>
+                <h1 class='print-page-toc-title'>{self.page_config["toc_title"]}</h1>
                 </nav>
             </div>
         </section>
@@ -228,11 +228,11 @@ class Renderer(object):
         Reference: https://github.com/mkdocs/mkdocs/blob/master/mkdocs/structure/toc.py
         """
 
-        if self.plugin_config.get("enumerate_headings"):
+        if self.page_config["enumerate_headings"]:
             chapter_number = 0
             section_number = 0
         toc = []
-        toc = self.get_toc_sidebar_section(items=self._get_items(),included_pages=self.page_config['include'], excluded_pages=self.page_config['exclude')
+        toc = self.get_toc_sidebar_section(items=self._get_items(),included_pages=self.page_config['include'], excluded_pages=self.page_config['exclude'])
 
 
         return TableOfContents(toc)

--- a/mkdocs_print_site_plugin/renderer.py
+++ b/mkdocs_print_site_plugin/renderer.py
@@ -21,7 +21,7 @@ class Renderer(object):
 
     def __init__(
         self,
-        plugin_config,
+        page_config,
         mkdocs_config=None,
         cover_page_template_path="",
         banner_template_path="",
@@ -30,7 +30,7 @@ class Renderer(object):
         """
         Inits the class.
         """
-        self.plugin_config = plugin_config
+        self.page_config = page_config
         self.mkdocs_config = mkdocs_config or {}
         self.cover_page_template_path = cover_page_template_path
         self.banner_template_path = banner_template_path
@@ -48,13 +48,13 @@ class Renderer(object):
         enabled_classes = []
 
         # Enable options via CSS
-        if self.plugin_config.get("add_full_urls"):
+        if self.page_config['add_full_urls']:
             enabled_classes.append("print-site-add-full-url")
 
-        if self.plugin_config.get("enumerate_headings"):
+        if self.page_config['enumerate_headings']:
             enabled_classes.append("print-site-enumerate-headings")
 
-        if self.plugin_config.get("enumerate_figures"):
+        if self.page_config['enumerate_figures']:
             enabled_classes.append("print-site-enumerate-figures")
 
         # Wrap entire print page in a div
@@ -62,13 +62,13 @@ class Renderer(object):
         html = '<div id="print-site-page" class="%s">' % " ".join(enabled_classes)
 
         # Enable options via HTML injection
-        if self.plugin_config.get("add_cover_page"):
+        if self.page_config['add_cover_page':
             html += self._cover_page()
 
-        if self.plugin_config.get("add_print_site_banner"):
+        if self.page_config['add_print_site_banner']:
             html += self._print_site_banner()
 
-        if self.plugin_config.get("add_table_of_contents"):
+        if self.page_config['add_table_of_contents']:
             html += self._toc()
 
         def get_html_from_items(
@@ -151,8 +151,8 @@ class Renderer(object):
         html += get_html_from_items(
             self._get_items(),
             dir_urls=self.mkdocs_config.get("use_directory_urls"),
-            included_pages=self.plugin_config.get("include", []),
-            excluded_pages=self.plugin_config.get("exclude", [])
+            included_pages=self.page_config['include],
+            excluded_pages=self.page_config['exclude']'
         )
 
         html += "</div>"
@@ -232,7 +232,7 @@ class Renderer(object):
             chapter_number = 0
             section_number = 0
         toc = []
-        toc = self.get_toc_sidebar_section(items=self._get_items(),included_pages=self.plugin_config.get("include", []), excluded_pages=self.plugin_config.get("exclude", []))
+        toc = self.get_toc_sidebar_section(items=self._get_items(),included_pages=self.page_config['include'], excluded_pages=self.page_config['exclude')
 
 
         return TableOfContents(toc)
@@ -254,7 +254,7 @@ class Renderer(object):
                 if page_key == "index":
                     page_key = ""
                 
-                if self.plugin_config.get("enumerate_headings"):
+                if self.page_config['enumerate_headings']:
                     chapter_number += 1
                     title = f"{chapter_number}. {item.title}"
                 else:
@@ -262,7 +262,7 @@ class Renderer(object):
                 toc.append(AnchorLink(title=title, id=f"{page_key}", level=0))
             
             if item.is_section:
-                if self.plugin_config.get("enumerate_headings"):
+                if self.page_config['enumerate_headings']:
                     section_number += 1
                     title = f"{int_to_roman(section_number)}. {item.title}"
                 else:
@@ -311,4 +311,5 @@ def int_to_roman(num):
     for (n, roman) in lookup:
         (d, num) = divmod(num, n)
         res += roman * d
+        
     return res

--- a/mkdocs_print_site_plugin/templates/cover_page.tpl
+++ b/mkdocs_print_site_plugin/templates/cover_page.tpl
@@ -5,6 +5,10 @@
         <h1>{{ config.site_name }}</h1>
     {% endif %}
 
+    {% if page_config.print_page_title %}
+        <h1>{{ page_config.print_page_title }}</h1>
+    {% endif %}
+
 </div>
 
 

--- a/mkdocs_print_site_plugin/utils.py
+++ b/mkdocs_print_site_plugin/utils.py
@@ -42,7 +42,7 @@ def find_new_root( root, path):
             return None
         for child in current_node.children:
             if child.is_section:
-                if child.title in next_part:
+                if child.title.lower() in next_part.lower():
                     return _find_node(child, parts[1:])
         
         return None  # If the node is not found

--- a/mkdocs_print_site_plugin/utils.py
+++ b/mkdocs_print_site_plugin/utils.py
@@ -25,7 +25,34 @@ def get_theme_name(config) -> str:
     else:
         return name
 
-
+def find_new_root( root, path):
+    # Split the path by '/'
+    path_parts = path.strip('/').split('/')
+    
+    # Recursive helper function
+    def _find_node(current_node, parts):
+        if not parts:
+            return current_node
+        
+        # Get the next part of the path
+        next_part = parts[0]
+        
+        # Look for the next node among the current node's children
+        if not hasattr(current_node, 'children'):
+            return None
+        for child in current_node.children:
+            if child.is_section:
+                if child.title in next_part:
+                    return _find_node(child, parts[1:])
+        
+        return None  # If the node is not found
+    for node in root:
+        if node.is_section:
+            if node.title == path_parts[0]:
+                return _find_node(node, path_parts[1:])
+    
+    return None
+    
 def flatten_nav(items):
     """
     Create a flat list of pages from a nested navigation.

--- a/tests/fixtures/projects/basic/docs/Sub1/b.md
+++ b/tests/fixtures/projects/basic/docs/Sub1/b.md
@@ -1,0 +1,4 @@
+# B
+
+This is page B, from `b.md`.
+

--- a/tests/fixtures/projects/basic/docs/Sub1/c.md
+++ b/tests/fixtures/projects/basic/docs/Sub1/c.md
@@ -1,0 +1,4 @@
+# C
+
+This is page C, from `c.md`.
+

--- a/tests/fixtures/projects/basic/docs/Sub1/sub1_exclude.md
+++ b/tests/fixtures/projects/basic/docs/Sub1/sub1_exclude.md
@@ -1,0 +1,3 @@
+# Exclude
+
+This is page Sub 1 Exclude, from `sub1_exclude.md`.

--- a/tests/fixtures/projects/basic/docs/Sub2/d.md
+++ b/tests/fixtures/projects/basic/docs/Sub2/d.md
@@ -1,0 +1,3 @@
+# D
+
+This is page D, from `d.md`.

--- a/tests/fixtures/projects/basic/docs/Sub2/e.md
+++ b/tests/fixtures/projects/basic/docs/Sub2/e.md
@@ -1,0 +1,3 @@
+# E
+
+This is page E, from `e.md`.

--- a/tests/fixtures/projects/basic/docs/Sub2/sub2_exclude.md
+++ b/tests/fixtures/projects/basic/docs/Sub2/sub2_exclude.md
@@ -1,0 +1,3 @@
+# Exclude
+
+This is page Sub 2 Exclude, from `exclude.md`.

--- a/tests/fixtures/projects/basic/docs/exclude.md
+++ b/tests/fixtures/projects/basic/docs/exclude.md
@@ -1,0 +1,3 @@
+# Exclude
+
+This is page Exclude, from `exclude.md`.

--- a/tests/fixtures/projects/basic/mkdocs_with_include_and_theme.yml
+++ b/tests/fixtures/projects/basic/mkdocs_with_include_and_theme.yml
@@ -1,0 +1,13 @@
+site_name: Test
+
+theme:
+    name: material
+    palette:
+        scheme: slate
+
+plugins:
+    - print-site:
+        add_to_navigation: true
+        include:
+          - z.md
+          - a.md

--- a/tests/fixtures/projects/basic/mkdocs_with_multi_pdf_and_theme.yml
+++ b/tests/fixtures/projects/basic/mkdocs_with_multi_pdf_and_theme.yml
@@ -1,0 +1,31 @@
+site_name: Test
+
+theme:
+    name: material
+    palette:
+        scheme: slate
+
+plugins:
+    - print-site:
+        add_to_navigation: true
+        exclude:
+            - exclude.md
+            - Sub2/sub2_exclude.md
+        pages_to_print:
+            - page_name: 'print_sub1'
+              config:
+                - add_table_of_contents: true
+                - print_page_title: "Sub 1 Title"
+                - print_docs_dir: "Sub1"
+                - exclude:
+                  - Sub1/sub1_exclude.md
+            - page_name: 'print_sub2'
+              config:
+                - add_table_of_contents: true
+                - print_page_title: "Sub 2 Title"
+                - add_to_navigation: false
+                - exclude:
+                   - '**exclude**'
+                - include:
+                   - z.md
+                   - Sub2*

--- a/tests/test_building.py
+++ b/tests/test_building.py
@@ -275,6 +275,68 @@ def test_basic_build7(tmp_path):
     """
     check_build(tmp_path, "bad_headings/mkdocs.yml", exit_code=0)
 
+
+def test_basic_build8(tmp_path):
+    """
+    Test include
+    """
+    prj_path = check_build(tmp_path, "basic/mkdocs_with_include_and_theme.yml")
+
+    # Print page should be in the navigation
+    assert text_in_page(
+        prj_path,
+        "index.html",
+        'href="print_page\/" class="md-nav__link"',
+    )
+
+    # Make sure the 2 pages are combined and present
+    assert text_in_page(prj_path, "print_page/index.html", '<h1 id="a-a">A</h1>')
+    assert text_in_page(prj_path, "print_page/index.html", '<h1 id="z-z">Z</h1>')
+
+def test_basic_build9(tmp_path):
+    """
+    Test include
+    """
+    prj_path = check_build(tmp_path, "basic/mkdocs_with_multi_pdf_and_theme.yml")
+
+    # Sub 1 print page should be in the navigation
+    assert text_in_page(
+        prj_path,
+        "index.html",
+        'href="print_sub1\/" class="md-nav__link"',
+    )
+    # Test  override
+    # Sub 2 print page should not be in navigation
+    assert not text_in_page(
+        prj_path,
+        "index.html",
+        'href="print_sub2\/" class="md-nav__link"',
+    )
+    # print_sub1 Tests
+    # Make sure the 2 pages are combined and present in sub1
+    assert text_in_page(prj_path, "print_sub1/index.html", 'This is page B')
+    assert text_in_page(prj_path, "print_sub1/index.html", 'This is page C')
+    assert text_in_page(prj_path, "print_sub1/index.html", 'Sub1')
+    # Make sure content not in Sub1 is excluded
+    assert not text_in_page(prj_path, "print_sub1/index.html", 'This is page Z')
+    assert not text_in_page(prj_path, "print_sub1/index.html", 'This is page A')
+    assert not text_in_page(prj_path, "print_sub1/index.html", 'This is page Exclude')
+    # Check exclude parameter
+    assert not text_in_page(prj_path, "print_sub1/index.html", 'This is page Sub 1 Exclude')
+
+    # print_sub2 Tests
+    # make sure sub 2 includes a, z, and sub2 folder
+    assert text_in_page(prj_path, "print_sub2/index.html", 'This is page Z')
+    assert text_in_page(prj_path, "print_sub2/index.html", 'This is page D')
+    assert text_in_page(prj_path, "print_sub2/index.html", 'This is page E')
+    assert not text_in_page(prj_path, "print_sub2/index.html", 'This is page Sub 1 Exclude')
+    assert not text_in_page(prj_path, "print_sub2/index.html", 'This is page Sub 2 Exclude')
+    assert not text_in_page(prj_path, "print_sub2/index.html", 'This is page Exclude')
+    
+
+
+
+
 def test_build_with_material_tags(tmp_path):
     """
     Test support with tags.


### PR DESCRIPTION
This adds the ability to define multiple pdfs by creating a dictionary of print_page settings with the key set to the print page name to generate.  It uses the original configuration inputs as globals for print_pages unless the print page config overrides the setting.  If print_pages is not defined within the mkdocs.yml then the configuration inputs add a single print_page item in the plugin print_pages.

This also resolves https://github.com/timvink/mkdocs-print-site-plugin/issues/76 by inspecting for the presence of child items within a section before adding to the TOC and Menu.