### PR TITLE
Update unittests_codecov.yml

### DIFF
--- a/.github/workflows/unittests_codecov.yml
+++ b/.github/workflows/unittests_codecov.yml
@@ -35,7 +35,7 @@ jobs:
         pytest --cov=mkdocs_print_site_plugin --cov-report=xml -vvv
     - name: Upload coverage to Codecov
       if: "contains(env.USING_COVERAGE, matrix.python-version)"
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml


### PR DESCRIPTION
Just updating the CodeCov action to v4 due to -

Run unit tests with codecov upload (macos-latest, 3.9)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: codecov/codecov-action@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

There might be a few changes required but hard to test as it will require a real upload to CodeCov.  Happy to troubleshoot if the first run fails.