### PR TITLE
Add option to change the print page URL

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -7,6 +7,7 @@ plugins:
   - print-site:
       add_to_navigation: false
       print_page_title: 'Print Site'
+      print_page_basename: 'print_page'
       add_print_site_banner: false
       # Table of contents
       add_table_of_contents: true
@@ -29,6 +30,9 @@ plugins:
 
 `print_page_title`
 :   Default is `'Print Site'`. When `add_to_navigation` is set to `true` this setting controls the name of the print page in the navigation of the site. This setting is ignored when `add_to_navigation` is set to `false`.
+
+`print_page_basename`
+:   Default is `'print_page'`. Can be used to cutomized the path to the print page in the URL.
 
 `add_table_of_contents`
 :   Default is `true`. Adds a table of contents section at the beginning of the print page (in print version, the HTML version has a different sidebar ToC).

--- a/mkdocs_print_site_plugin/plugin.py
+++ b/mkdocs_print_site_plugin/plugin.py
@@ -27,6 +27,7 @@ class PrintSitePlugin(BasePlugin):
     config_scheme = (
         ("add_to_navigation", config_options.Type(bool, default=False)),
         ("print_page_title", config_options.Type(str, default="Print Site")),
+        ("print_page_basename", config_options.Type(str, default="print_page")),
         ("add_table_of_contents", config_options.Type(bool, default=True)),
         ("toc_title", config_options.Type(str, default="Table of Contents")),
         ("toc_depth", config_options.Type(int, default=3)),
@@ -153,7 +154,7 @@ class PrintSitePlugin(BasePlugin):
 
         # Create MkDocs Page and File instances
         self.print_file = File(
-            path="print_page.md",
+            path=self.config.get("print_page_basename") + ".md",
             src_dir="",
             dest_dir=config["site_dir"],
             use_directory_urls=config.get("use_directory_urls"),


### PR DESCRIPTION
This adds an option (`print_page_basename`) that affects the filename for the print page so you can have some control over its URL.