### PR TITLE
Fix for invalid warning when using hooks in mkdocs

### DIFF
--- a/mkdocs_print_site_plugin/plugin.py
+++ b/mkdocs_print_site_plugin/plugin.py
@@ -63,7 +63,15 @@ class PrintSitePlugin(BasePlugin):
         # it is important 'print-site' is defined last in the 'plugins'
         plugins = config.get("plugins")
         print_site_position = [*dict(plugins)].index("print-site")
-        if print_site_position != len(plugins) - 1:
+
+        # Offset begins at 1 due to indexing starting at 0
+        position_offset = 1
+
+        # Check if 'hooks' is defined in the 'plugins' section
+        if isinstance(config.get("hooks"), dict):
+            position_offset += len(config.get("hooks"))
+            
+        if print_site_position != len(plugins) - position_offset:
             msg = "[mkdocs-print-site] 'print-site' should be defined as the *last* plugin,"
             msg += "to ensure the print page has any changes other plugins make."
             msg += "Please update the 'plugins:' section in your mkdocs.yml"


### PR DESCRIPTION
The following configuration in the mkdocs.yaml file kept creating this warning despite having the print-site pluggin defined as the last pluggin:
![image](https://github.com/user-attachments/assets/f03431c5-66f4-4a7e-b550-5a5a99d6d227)
![image](https://github.com/user-attachments/assets/6530b656-780b-4eac-b735-102c4541dcc4)

This behaviour can be explained by the fact that hooks are now added to the pluggin config in mkdocs:
![image](https://github.com/user-attachments/assets/e327424b-898f-4576-b343-6c932d3d41cc)

Thus only checking if the pluggin is in the last position will not work if custom hooks are provided. Therefore we also check how many hooks are provided and keep this in mind when checking for the right pluggin position.

Resulting in:
![image](https://github.com/user-attachments/assets/b3a33285-e7ad-4d33-a6c4-2942142a0210)
