### PR TITLE
Fix TOC in base theme

### DIFF
--- a/src/mkdocs_print_site_plugin/js/print-site.js
+++ b/src/mkdocs_print_site_plugin/js/print-site.js
@@ -7,7 +7,9 @@ Copy the table of contents from the sidebar's.
 Only called when print-site-plugin option 'add_table_of_contents' is set to true
 */
 function generate_toc() {
-  const sidebar = document.body.getElementsByClassName("md-sidebar--secondary")[0];
+  const sidebar = document.body.getElementsByClassName("md-sidebar--secondary")[0] ??
+    document.getElementById("toc-collapse");
+
   const sidebarToc = sidebar.getElementsByTagName("ul")[0];
 
   var clonedToc = sidebarToc.cloneNode(true);


### PR DESCRIPTION
This PR addresses issue #135.

My PR #128 used the same souce for the sidebar TOC and the front page TOC, but in doing so assumed Material for MkDocs was being used, which is not necessarily the case. These changes provide a fallback to pick up the base theme sidebar when Material for MkDocs is not being used, effectively solving that issue.