### PR TITLE
Update plugin.py to add support for mkdocs-autorefs

### DIFF
--- a/src/mkdocs_print_site_plugin/plugin.py
+++ b/src/mkdocs_print_site_plugin/plugin.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import functools
+import re as regex_module
 
 
 from mkdocs.config import config_options
@@ -341,7 +342,6 @@ class PrintSitePlugin(BasePlugin):
             from mkdocs_autorefs._internal.references import fix_refs
             
             # First, extract all available anchors from the HTML
-            import re as regex_module
             anchor_pattern = r'(?:id="([^"]+)"|name="([^"]+)")'
             anchor_matches = regex_module.findall(anchor_pattern, html, regex_module.IGNORECASE)
             available_anchors = set()

--- a/src/mkdocs_print_site_plugin/plugin.py
+++ b/src/mkdocs_print_site_plugin/plugin.py
@@ -3,7 +3,6 @@ import os
 import re
 import sys
 import functools
-import re as regex_module
 
 
 from mkdocs.config import config_options
@@ -417,12 +416,6 @@ class PrintSitePlugin(BasePlugin):
             )
             if unmapped:
                 logger.warning(f"[mkdocs-print-site] Unmapped autorefs: {[ref for ref, _ in unmapped]}")
-        else:
-            logger.info("[mkdocs-print-site] No autorefs plugin found")                   
-            except ImportError:
-                logger.warning("[mkdocs-print-site] mkdocs-autorefs not available for processing")
-            except Exception as e:
-                logger.warning(f"[mkdocs-print-site] Error processing autorefs: {e}")
 
         # Compatibility with https://github.com/g-provost/lightgallery-markdown
         # This plugin insert link hrefs with double dashes, f.e.

--- a/src/mkdocs_print_site_plugin/plugin.py
+++ b/src/mkdocs_print_site_plugin/plugin.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import functools
+import re as regex_module
 
 
 from mkdocs.config import config_options


### PR DESCRIPTION
@timvink Cavaet - I'm no developer, and this was written with Claude Sonnet 4 over several trial-and-error iterations. I tested in my output pdf, and the autoref links are working as expected. YMMV.